### PR TITLE
Fix a bug to save processed IODA IMS files into designated directory

### DIFF
--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -343,6 +343,8 @@ if [[ ${DAtype} == 'letkfoi_snow' ]]; then
         SNOWDEPTHVAR="snwdph"
     fi
 
+    ln -s ${TPATH}/${TSTUB}* ${JEDIWORKDIR}
+
     B=30  # back ground error std for LETKFOI
 
     # FOR LETKFOI, CREATE THE PSEUDO-ENSEMBLE
@@ -445,15 +447,10 @@ fi
 ################################################
 
 # keep IMS IODA file
-# YX: modify IMS IODA filenames, otherwise IMSscf files can never be saved (08/09/2023)
 if [ $SAVE_IMS == "YES"  ]; then
-  # if [[ -e ${JEDIWORKDIR}/ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ]]; then
-  #    cp ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ${OUTDIR}/DA/IMSproc/
-  # fi
-  if [[ -e ${JEDIWORKDIR}/ioda.IMSscf.${YYYY}${MM}${DD}.oro_C${RES}.mx100.nc ]]; then
-      cp ${JEDIWORKDIR}/ioda.IMSscf.${YYYY}${MM}${DD}.oro_C${RES}.mx100.nc ${OUTDIR}/DA/IMSproc/
-  fi
-
+   if [[ -e ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc ]]; then
+      cp ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc ${OUTDIR}/DA/IMSproc/
+   fi
 fi 
 
 # keep increments

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -238,7 +238,7 @@ do_HOFX="NO"
 for ii in "${!OBS_TYPES[@]}"; # loop through requested obs
 do
    if [ ${JEDI_TYPES[$ii]} == "DA" ]; then 
-         export do_DA="YES" 
+         do_DA="YES" 
    elif [ ${JEDI_TYPES[$ii]} == "HOFX" ]; then
          do_HOFX="YES" 
    elif [ ${JEDI_TYPES[$ii]} != "SKIP" ]; then
@@ -343,8 +343,6 @@ if [[ ${DAtype} == 'letkfoi_snow' ]]; then
         SNOWDEPTHVAR="snwdph"
     fi
 
-    ln -s ${TPATH}/${TSTUB}* ${JEDIWORKDIR}
-
     B=30  # back ground error std for LETKFOI
 
     # FOR LETKFOI, CREATE THE PSEUDO-ENSEMBLE
@@ -447,10 +445,15 @@ fi
 ################################################
 
 # keep IMS IODA file
+# YX: modify IMS IODA filenames, otherwise IMSscf files can never be saved (08/09/2023)
 if [ $SAVE_IMS == "YES"  ]; then
-   if [[ -e ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ]]; then
-      cp ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ${OUTDIR}/DA/IMSproc/
-   fi
+  # if [[ -e ${JEDIWORKDIR}/ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ]]; then
+  #    cp ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ${OUTDIR}/DA/IMSproc/
+  # fi
+  if [[ -e ${JEDIWORKDIR}/ioda.IMSscf.${YYYY}${MM}${DD}.oro_C${RES}.mx100.nc ]]; then
+      cp ${JEDIWORKDIR}/ioda.IMSscf.${YYYY}${MM}${DD}.oro_C${RES}.mx100.nc ${OUTDIR}/DA/IMSproc/
+  fi
+
 fi 
 
 # keep increments


### PR DESCRIPTION
Please review: @ClaraDraper-NOAA. This is the bug fix that we discussed on 08/08. Per your request, I am creating the pull request here. On 08/25, I made edits to the script based on your comments. Please review again. Thank you!  -Yuan, 08/29

## Describe your changes  
Summarise all code changes included in PR: 
- Removed the redundant exported feature of "do_DA".
- Passed in $TSTUB variable in IODA IMS filenames to save them properly into the designated directory in case users want to check these files in the output directory without keeping the jedi working directory. 

List any associated PRs  in the submodules.
N/A

## Issue ticket number and link
N/A


## Test output 
Is this PR expected to pass the DA_IMS_test (ie., does it change the output)? 
- Yes, it is expected.

Does it pass the DA_IMS_test? 
- Yes, it does.

If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 
N/A.

## Checklist before requesting a review
- [x] My branch being merged is up to date with the latest develop. 
- [x] I have performed a self-review of my code by examining the differences that will be merged.
- [x] I have not made any unnecessary code changes / changed any default behavior.
- [x] My code passes the DA_IMS_test, or differences can be explained. 

