### PR TITLE
Use the ShadowLevels bump file in the 2Dvar snow DA

### DIFF
--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -446,14 +446,15 @@ else
     SNOWDEPTHVAR="snwdph"
 fi
 
+JEDI_EXEC="gdas.x"
 if [[ ${DAalg} == '2DVar' ]]; then
 
-    JEDI_EXEC="gdas.x"
+    SOLVER="variational"
 
 elif [[ ${DAalg} == 'letkfoi' ]]; then
 #To-do: make this section generic (currently assumes snow)
 
-    JEDI_EXEC="fv3jedi_letkf.x"
+    SOLVER="letkf"
     
     B=30  # back ground error std for LETKFOI
 
@@ -482,13 +483,13 @@ elif [[ ${DAalg} == 'letkfoi' ]]; then
 elif [[ ${DAalg} == 'letkfoi_smc' ]]; then
 # To-do : combine this with the above
 
-    JEDI_EXEC="fv3jedi_letkf.x"
+    SOLVER="letkf"
     
     cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/gfs-soilMoisture.yaml ${JEDIWORKDIR}/gfs-soilMoisture.yaml
 
 elif [[ ${DAalg} == 'letkf' ]]; then
 
-    JEDI_EXEC="fv3jedi_letkf.x"
+    SOLVER="letkf"
 
     if [[ $do_DA == "YES" && $YAML_DA == "construct" ]];then
 
@@ -550,7 +551,7 @@ fi
 echo 'do_landDA: calling fv3-jedi' 
 
 if [[ $do_DA == "YES" ]]; then
-    time srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} fv3jedi variational jedi_DA.yaml ${LOGDIR}/jedi_DA.log
+    time srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} fv3jedi ${SOLVER} jedi_DA.yaml ${LOGDIR}/jedi_DA.log
     if [[ $? != 0 ]]; then
         echo "JEDI DA failed"
         exit 10

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -558,7 +558,7 @@ if [[ $do_DA == "YES" ]]; then
     fi
 fi 
 if [[ $do_HOFX == "YES" ]]; then  
-    time srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} jedi_hofx.yaml ${LOGDIR}/jedi_hofx.log
+    time srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} fv3jedi ${SOLVER} jedi_hofx.yaml ${LOGDIR}/jedi_hofx.log
     if [[ $? != 0 ]]; then
         echo "JEDI hofx failed"
         exit 10

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -448,7 +448,7 @@ fi
 
 if [[ ${DAalg} == '2DVar' ]]; then
 
-    JEDI_EXEC="fv3jedi_var.x"
+    JEDI_EXEC="gdas.x"
 
 elif [[ ${DAalg} == 'letkfoi' ]]; then
 #To-do: make this section generic (currently assumes snow)
@@ -550,7 +550,7 @@ fi
 echo 'do_landDA: calling fv3-jedi' 
 
 if [[ $do_DA == "YES" ]]; then
-    time srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} jedi_DA.yaml ${LOGDIR}/jedi_DA.log
+    time srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} fv3jedi variational jedi_DA.yaml ${LOGDIR}/jedi_DA.log
     if [[ $? != 0 ]]; then
         echo "JEDI DA failed"
         exit 10

--- a/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
@@ -26,7 +26,6 @@ variational:
       layout: [3,4]
       io_layout: [1,1]
       field metadata override: Data/fieldmetadata/gfs-land.yaml
-      #field metadata override: Data/fieldmetadata/fv3jedi_fieldmetadata_restart.yaml
       time invariant fields:
         state fields:
           datetime: XXYYYB-XXMB-XXDBTXXHB:00:00Z
@@ -80,7 +79,6 @@ cost function:
     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
     filename_orog: CXXRES.XXORES_oro_data.nc
     state variables: [totalSnowDepth,vtype,slmsk,sheleg,orog_filt]
-    #state variables: [snodl,vtype,slmsk,sheleg,orog_filt]
   background error:
     covariance model: SABER
     saber central block:
@@ -107,7 +105,7 @@ cost function:
             type: c0
           same horizontal convolution: true
         io:
-          data directory: /scratch1/NCEPDEV/global/Jiarui.Dong/JEDI/workflow/bump_snow/
+          data directory: /scratch2/NCEPDEV/land/data/DA/bump_snow/
           files prefix: snow_bump_nicas_250km_shadowlevels
     saber outer blocks:
     - saber block name: ShadowLevels

--- a/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
@@ -15,9 +15,6 @@ variational:
   - ninner: 50
     gradient norm reduction: 1e-10
     geometry:                           # minimization at lower resolution
-      #fms initialization:
-      #  namelist filename: Data/fv3jedi/fmsmpp.nml
-      #  field table filename: Data/fv3jedi/field_table
       akbk: Data/fv3files/akbk127.nc4
       npx: XXREP
       npy: XXREP

--- a/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
@@ -46,6 +46,7 @@ cost function:
   time window:
     begin: XXYYYB-XXMB-XXDBTXXHB:00:00Z
     length: PTXXWINLENH
+    bound to include: begin
   analysis variables: [totalSnowDepth] 
   geometry:
     npx: XXREP

--- a/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
@@ -15,14 +15,18 @@ variational:
   - ninner: 50
     gradient norm reduction: 1e-10
     geometry:                           # minimization at lower resolution
+      fms initialization:
+        namelist filename: Data/fv3jedi/fmsmpp.nml
+        field table filename: Data/fv3jedi/field_table
       akbk: Data/fv3files/akbk127.nc4
       npx: XXREP
       npy: XXREP
       npz: 127
       ntiles: 6
-      #layout: [3,4]
-      #io_layout: [1,1]
-      #field metadata override: Data/fieldmetadata/gfs_v17-land.yaml
+      layout: [3,4]
+      io_layout: [1,1]
+      field metadata override: Data/fieldmetadata/gfs-land.yaml
+      #field metadata override: Data/fieldmetadata/fv3jedi_fieldmetadata_restart.yaml
       time invariant fields:
         state fields:
           datetime: XXYYYB-XXMB-XXDBTXXHB:00:00Z
@@ -48,21 +52,21 @@ cost function:
     length: PTXXWINLENH
   analysis variables: [totalSnowDepth] 
   geometry:
+    fms initialization:
+      namelist filename: Data/fv3files/fmsmpp.nml
+      field table filename: Data/fv3files/field_table
+    akbk: Data/fv3files/akbk127.nc4
     npx: XXREP
     npy: XXREP
     npz: 127
     ntiles: 6
-    #layout:
-    #- 3
-    #- 4
-    #io_layout:
-    #- 1
-    #- 1
+    layout:
+    - 3
+    - 4
+    io_layout:
+    - 1
+    - 1
     _resol_name: cXXRES
-    akbk: Data/fv3files/akbk127.nc4
-    fms initialization:
-      namelist filename: Data/fv3files/fmsmpp.nml
-      field table filename: Data/fv3files/field_table
     field metadata override: Data/fieldmetadata/gfs-land.yaml
   analysis variables:
   - totalSnowDepth
@@ -75,7 +79,8 @@ cost function:
     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
     filename_orog: CXXRES.XXORES_oro_data.nc
-    state variables: [totalSnowDepth,vtype,slmsk,orog_filt]
+    state variables: [totalSnowDepth,vtype,slmsk,sheleg,orog_filt]
+    #state variables: [snodl,vtype,slmsk,sheleg,orog_filt]
   background error:
     covariance model: SABER
     saber central block:
@@ -90,29 +95,29 @@ cost function:
           explicit length-scales: true
           horizontal length-scale:
           - groups:
-            - totalSnowDepth_fakeLevels
-            value: 300000.0
+            - totalSnowDepth_shadowLevels
+            value: 250000.0
           vertical length-scale:
           - groups:
-            - totalSnowDepth_fakeLevels
+            - totalSnowDepth_shadowLevels
             value: 0.0
           interpolation type:
           - groups:
-            - totalSnowDepth_fakeLevels
+            - totalSnowDepth_shadowLevels
             type: c0
           same horizontal convolution: true
         io:
-          data directory: /scratch2/BMC/gsienkf/Clara.Draper/jedi/bump_snow/
-          files prefix: snow_bump_nicas_300km_fakelevels
+          data directory: /scratch1/NCEPDEV/global/Jiarui.Dong/JEDI/workflow/bump_snow/
+          files prefix: snow_bump_nicas_250km_shadowlevels
     saber outer blocks:
-    - saber block name: FakeLevels
+    - saber block name: ShadowLevels
       fields metadata:
         totalSnowDepth:
           vert_coord: filtered_orography
       calibration:
-        number of fake levels: 50
-        lowest fake level: -450.0
-        highest fake level: 8850.0
+        number of shadow levels: 50
+        lowest shadow level: -450.0
+        highest shadow level: 8850.0
         vertical length-scale: 2000.0
     - saber block name: BUMP_StdDev
       read:

--- a/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/2DVar/snow.yaml
@@ -15,17 +15,17 @@ variational:
   - ninner: 50
     gradient norm reduction: 1e-10
     geometry:                           # minimization at lower resolution
-      fms initialization:
-        namelist filename: Data/fv3jedi/fmsmpp.nml
-        field table filename: Data/fv3jedi/field_table
+      #fms initialization:
+      #  namelist filename: Data/fv3jedi/fmsmpp.nml
+      #  field table filename: Data/fv3jedi/field_table
       akbk: Data/fv3files/akbk127.nc4
       npx: XXREP
       npy: XXREP
       npz: 127
       ntiles: 6
-      layout: [3,4]
-      io_layout: [1,1]
-      field metadata override: Data/fieldmetadata/gfs-land.yaml
+      #layout: [3,4]
+      #io_layout: [1,1]
+      #field metadata override: Data/fieldmetadata/gfs_v17-land.yaml
       time invariant fields:
         state fields:
           datetime: XXYYYB-XXMB-XXDBTXXHB:00:00Z
@@ -51,21 +51,21 @@ cost function:
     length: PTXXWINLENH
   analysis variables: [totalSnowDepth] 
   geometry:
-    fms initialization:
-      namelist filename: Data/fv3files/fmsmpp.nml
-      field table filename: Data/fv3files/field_table
-    akbk: Data/fv3files/akbk127.nc4
     npx: XXREP
     npy: XXREP
     npz: 127
     ntiles: 6
-    layout:
-    - 3
-    - 4
-    io_layout:
-    - 1
-    - 1
+    #layout:
+    #- 3
+    #- 4
+    #io_layout:
+    #- 1
+    #- 1
     _resol_name: cXXRES
+    akbk: Data/fv3files/akbk127.nc4
+    fms initialization:
+      namelist filename: Data/fv3files/fmsmpp.nml
+      field table filename: Data/fv3files/field_table
     field metadata override: Data/fieldmetadata/gfs-land.yaml
   analysis variables:
   - totalSnowDepth

--- a/make_links.sh
+++ b/make_links.sh
@@ -4,15 +4,21 @@ if [ $# == 1 ]; then
         echo "setting jedi path to input $1"
         GDASApp_path=$1
 else 
-        GDASApp_path="/scratch2/NCEPDEV/land/data/DA/GDASApp_20240911/"
+        GDASApp_path="/scratch2/NCEPDEV/land/data/DA/GDASApp_20250207/"
 fi 
 
 # create link to GDASApp with executables:
-yes|rm ./GDASApp    # delete to deal with "permission denied" when link exists
-ln -fs $GDASApp_path ./GDASApp
+gdasdir="./GDASApp"
+if [[ -e $gdasdir ]]; then
+  rm $gdasdir
+fi
+ln -fs $GDASApp_path $gdasdir
 
-# link fv3files 
-yes|rm jedi/fv3-jedi/Data/fv3files
-ln -fs ${GDASApp_path}/build/fv3-jedi/test/Data/fv3files jedi/fv3-jedi/Data/fv3files
+# link fv3files
+fv3files="jedi/fv3-jedi/Data/fv3files"
+if [[ -e $fv3files ]]; then
+  rm $fv3files
+fi
+ln -fs ${GDASApp_path}/build/fv3-jedi/test/Data/fv3files $fv3files
 
 


### PR DESCRIPTION
## Describe your changes  

This PR modified the `snow.yaml` to use the `ShadowLevels` bump file as same as the bump file currently used in the global-workflow. 
This PR also modified the `do_landDA.sh` script for using new JEDI executable. 
This PR also modified the `make_links.sh` to avoid error warning in making links during the first time. 

List any associated PRs  in the submodules.
https://github.com/NOAA-PSL/land-offline_workflow/pull/40

## Issue ticket number and link
List the git Issue that this PR addresses: 
https://github.com/NOAA-PSL/land-DA_update/issues/30

## Test output 
Is this PR expected to pass the DA_IMS_test (ie., does it change the output)? 

Does it pass the DA_IMS_test? 

If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 

## Checklist before requesting a review
- [ ] My branch being merged is up to date with the latest develop. 
- [ ] I have performed a self-review of my code by examining the differences that will be merged.
- [ ] I have not made any unnecessary code changes / changed any default behavior.
- [ ] My code passes the DA_IMS_test, or differences can be explained. 

