### PR TITLE
Update to latest JEDI version from GDASApp

### DIFF
--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -226,10 +226,7 @@ do
   elif [ ${OBS_TYPES[$ii]} == "MADIS" ]; then
      obsfile=$OBSDIR/snow_depth/MADIS/data_proc/v3/${YYYY}/madis_snow_${YYYY}${MM}${DD}_${HH}00.nc
   elif [ ${OBS_TYPES[$ii]} == "GHCN" ]; then 
-  # GHCN are time-stamped at 18. If assimilating at 00, need to use previous day's obs, so that 
-  # obs are within DA window.
-     #obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYP}/ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
-     obsfile=$OBSDIR/snow_depth/GHCN/processed_data/${YYYY}/ghcn_snwd_ioda_${YYYY}${MM}${DD}.nc
+     obsfile=$OBSDIR/snow_depth/GHCN/processed_data/${YYYY}/${YYYY}${MM}${DD}.csv
   elif [ ${OBS_TYPES[$ii]} == "SYNTH" ]; then 
      obsfile=$OBSDIR/synthetic_noahmp/IODA.synthetic_gswp_obs.${YYYY}${MM}${DD}${HH}.nc
   elif [ ${OBS_TYPES[$ii]} == "SMAP" ]; then
@@ -266,20 +263,18 @@ do
   # check obs are available
   if [[ -e $obsfile ]]; then
     echo "do_landDA: ${OBS_TYPES[$ii]} observations found: $obsfile"
-    if [ ${OBS_TYPES[$ii]} != "IMS" ]; then 
-       ln -fs $obsfile  ${OBS_TYPES[$ii]}_${YYYY}${MM}${DD}${HH}.nc
-    fi 
   else
     echo "${OBS_TYPES[$ii]} observations not found: $obsfile"
     JEDI_TYPES[$ii]="SKIP"
   fi
 
-  # pre-process and call IODA converter for IMS obs.
-  if [[ ${OBS_TYPES[$ii]} == "IMS"  && ${JEDI_TYPES[$ii]} != "SKIP" ]]; then
+  # get the obs
+  if [[ ${JEDI_TYPES[$ii]} != "SKIP" ]]; then
+      if [[ ${OBS_TYPES[$ii]} == "IMS" ]]; then
 
-    if [[ -e fims.nml ]]; then
-        rm -rf fims.nml 
-    fi
+        if [[ -e fims.nml ]]; then
+            rm -rf fims.nml 
+        fi
 cat >> fims.nml << EOF
  &fIMS_nml
   idim=$RES, jdim=$RES,
@@ -294,27 +289,44 @@ cat >> fims.nml << EOF
   IMS_IND_PATH="${OBSDIR}/snow_ice_cover/IMS/index_files/",
   /
 EOF
-    echo 'do_landDA: calling fIMS'
+        echo 'do_landDA: calling fIMS'
 
-    ${FIMS_EXECDIR}/calcfIMS.exe
-    if [[ $? != 0 ]]; then
-        echo "fIMS failed"
-        exit 10
-    fi
+        ${FIMS_EXECDIR}/calcfIMS.exe
+        if [[ $? != 0 ]]; then
+            echo "fIMS failed"
+            exit 10
+        fi
 
-    IMS_IODA=imsfv3_scf2iodaTemp.py # 2024-07-12 temporary until GDASApp ioda converter updated.
-    cp ${LANDDADIR}/jedi/ioda/${IMS_IODA} $JEDIWORKDIR
+        IODA_CONV=imsfv3_scf2iodaTemp.py # 2024-07-12 temporary until GDASApp ioda converter updated.
+        cp ${LANDDADIR}/jedi/ioda/${IODA_CONV} $JEDIWORKDIR
 
-    echo 'do_landDA: calling ioda converter' 
+        echo 'do_landDA: calling ioda converter' 
 
-    python ${IMS_IODA} -i IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc -o ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc 
-    if [[ $? != 0 ]]; then
-        echo "IMS IODA converter failed"
-        exit 10
-    fi
-  fi #IMS
+        python ${IODA_CONV} -i IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc -o ${JEDIWORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc 
+        if [[ $? != 0 ]]; then
+            echo "IMS IODA converter failed"
+            exit 10
+        fi
+      elif [[ ${OBS_TYPES[$ii]} == "GHCN" ]]; then
 
-done # OBS_TYPES
+        IODA_CONV=ghcn_snod2ioda.py
+
+        cp ${LANDDADIR}/jedi/ioda/${IODA_CONV} $JEDIWORKDIR
+        cp ${OBSDIR}/snow_depth/GHCN/downloaded_data/ghcnd-stations.txt $JEDIWORKDIR
+
+        echo 'do_landDA: calling ioda converter' 
+
+        python ${IODA_CONV} -i ${obsfile} -o ${JEDIWORKDIR}/GHCN_${YYYY}${MM}${DD}${HH}.nc -f ${JEDIWORKDIR}/ghcnd-stations.txt -d ${YYYY}${MM}${DD}${HH}
+        if [[ $? != 0 ]]; then
+            echo "GHCN IODA converter failed"
+            exit 10
+        fi
+     
+      else
+       ln -fs $obsfile  ${OBS_TYPES[$ii]}_${YYYY}${MM}${DD}${HH}.nc
+      fi #OBS_TYPES
+  fi # is not skip
+done # if assim
 
 ################################################
 # 3. DETERMINE REQUESTED JEDI TYPE, CONSTRUCT YAMLS

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -43,7 +43,7 @@ IOLayY=${IOLayY:-1}
 source ${LANDDADIR}/env_GDASApp
 
 LOGDIR=${OUTDIR}/DA/logs/
-OBSDIR=${OBSDIR:-"/scratch2/NCEPDEV/land/data/DA/"}
+OBSDIR=${OBSDIR:-"/scratch4/NCEPDEV/land/data/DA/"}
 
 # set executable directories
 
@@ -228,7 +228,8 @@ do
   elif [ ${OBS_TYPES[$ii]} == "GHCN" ]; then 
   # GHCN are time-stamped at 18. If assimilating at 00, need to use previous day's obs, so that 
   # obs are within DA window.
-     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYP}/ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
+     #obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYP}/ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
+     obsfile=$OBSDIR/snow_depth/GHCN/processed_data/${YYYY}/ghcn_snwd_ioda_${YYYY}${MM}${DD}.nc
   elif [ ${OBS_TYPES[$ii]} == "SYNTH" ]; then 
      obsfile=$OBSDIR/synthetic_noahmp/IODA.synthetic_gswp_obs.${YYYY}${MM}${DD}${HH}.nc
   elif [ ${OBS_TYPES[$ii]} == "SMAP" ]; then

--- a/env_GDASApp
+++ b/env_GDASApp
@@ -9,11 +9,20 @@ export dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 export GDASApp_root=${dir_root}/GDASApp/
 
 # environment for GDASApp 
+
 COMPILER="${COMPILER:-intel}"
 source $GDASApp_root/ush/detect_machine.sh
 source $GDASApp_root/ush/module-setup.sh
+
+module purge
 module use $GDASApp_root/modulefiles
 module load GDAS/${MACHINE_ID}.$COMPILER
 
 # set pythonpath for ioda converters
-export PYTHONPATH=$PYTHONPATH:/scratch2/NCEPDEV/land/data/DA/GDASApp/sorc/iodaconv/src/:/scratch2/NCEPDEV/land/data/DA/GDASApp/build/lib/python3.10
+IODA_CONV=${GDASApp_root}/sorc/iodaconv/src/
+IODAPY=${GDASApp_root}/build/lib/python3.11/
+
+export PYTHONPATH=$PYTHONPATH:${IODA_CONV}:${GDASApp_root}/build/lib/python3.11/:${IODAPY}
+
+# turn off exit on error (set in detect_machine.sh)
+set +e 

--- a/env_GDASApp
+++ b/env_GDASApp
@@ -18,9 +18,11 @@ module purge
 module use $GDASApp_root/modulefiles
 module load GDAS/${MACHINE_ID}.$COMPILER
 
+PYVN=$(python -c 'import sys; print(".".join(sys.version.split(" ")[0].split(".")[0:2]))')
+
 # set pythonpath for ioda converters
 IODA_CONV=${GDASApp_root}/sorc/iodaconv/src/
-IODAPY=${GDASApp_root}/build/lib/python3.11/
+IODAPY=${GDASApp_root}/build/lib/python${PYVN}/
 
 export PYTHONPATH=$PYTHONPATH:${IODA_CONV}:${GDASApp_root}/build/lib/python3.11/:${IODAPY}
 

--- a/jedi/fv3-jedi/yaml_files/ghcn_snowanlvar.yaml
+++ b/jedi/fv3-jedi/yaml_files/ghcn_snowanlvar.yaml
@@ -2,8 +2,8 @@ cost function:
   cost type: 3D-Var
   jb evaluation: false
   time window:
-    begin: '2019-11-30T12:00:00Z'
-    length: PT24H
+    begin: 'XXYYYB-XXMB-XXDBTXXHB:00:00Z'
+    length: PTXXWINLENH
     bound to include: end
   geometry:
     fms initialization:
@@ -13,8 +13,8 @@ cost function:
     #layout:
     #- 5
     #- 5
-    npx: 97
-    npy: 97
+    npx: XXREP
+    npy: XXREP
     npz: 127
   analysis variables:
   - totalSnowDepth
@@ -22,7 +22,7 @@ cost function:
     datapath: ./restarts/
     filetype: fms restart
     skip coupler file: true
-    datetime: '2019-12-01T00:00:00Z'
+    datetime: 'XXYYYY-XXMM-XXDDTXXHH:00:00Z'
     state variables:
     - totalSnowDepth
     - vtype
@@ -36,9 +36,9 @@ cost function:
       filtered_orography: orog_filt
       #fraction_of_ice: fice
       fraction_of_land: land_frac
-    filename_sfcd: 20191201.000000.sfc_data.nc
-    filename_cplr: 20191201.000000.coupler.res
-    filename_orog: C96.mx100_oro_data.nc
+    filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+    filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+    filename_orog: CXXRES.XXORES_oro_data.nc
   background error:
     covariance model: SABER
     saber central block:
@@ -95,12 +95,12 @@ cost function:
         obsdatain:
           engine:
             type: H5File
-            obsfile: GHCN_2019120100.nc
+            obsfile: GHCN_XXYYYYXXMMXXDDXXHH.nc
             missing file action: warn
         obsdataout:
           engine:
             type: H5File
-            obsfile: output/DA/hofx/var_hofx_ghcn_2019120100.nc
+            obsfile: output/DA/hofx/var_hofx_ghcn_XXYYYYXXMMXXDDXXHH.nc
         simulated variables:
         - totalSnowDepth
       obs operator:
@@ -301,12 +301,12 @@ variational:
       #layout:
       #- 5
       #- 5
-      npx: 97
-      npy: 97
+      npx: XXREP
+      npy: XXREP
       npz: 127
       time invariant fields:
         state fields:
-          datetime: '2019-12-01T00:00:00Z'
+          datetime: 'XXYYYY-XXMM-XXDDTXXHH:00:00Z'
           filetype: fms restart
           skip coupler file: true
           state variables:
@@ -316,7 +316,7 @@ variational:
             filtered_orography: orog_filt
             fraction_of_land: land_frac
           #datapath: 
-          filename_orog: C96.mx100_oro_data.nc
+          filename_orog: CXXRES.XXORES_oro_data.nc
     diagnostics:
       departures: bkgmob
 final:
@@ -330,8 +330,8 @@ final:
         datapath: ./
         prefix: snowinc
         filetype: fms restart
-        filename_sfcd: 20191201.000000.sfc_data.nc
-        filename_cplr: 20191201.000000.coupler.res
+        filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+        filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
         state variables:
         - totalSnowDepth
         - vtype
@@ -346,7 +346,7 @@ final:
       #layout:
       #- 5
       #- 5
-      npx: 97
-      npy: 97
+      npx: XXREP
+      npy: XXREP
       npz: 127
 final j evaluation: false

--- a/jedi/fv3-jedi/yaml_files/ghcn_snowanlvar.yaml
+++ b/jedi/fv3-jedi/yaml_files/ghcn_snowanlvar.yaml
@@ -1,0 +1,352 @@
+cost function:
+  cost type: 3D-Var
+  jb evaluation: false
+  time window:
+    begin: '2019-11-30T12:00:00Z'
+    length: PT24H
+    bound to include: end
+  geometry:
+    fms initialization:
+      namelist filename: Data/fv3files/fmsmpp.nml
+      field table filename: Data/fv3files/field_table_gfdl
+    akbk: Data/fv3files/akbk127.nc4
+    #layout:
+    #- 5
+    #- 5
+    npx: 97
+    npy: 97
+    npz: 127
+  analysis variables:
+  - totalSnowDepth
+  background:
+    datapath: ./restarts/
+    filetype: fms restart
+    skip coupler file: true
+    datetime: '2019-12-01T00:00:00Z'
+    state variables:
+    - totalSnowDepth
+    - vtype
+    - slmsk
+    - sheleg
+    - filtered_orography
+    #- fraction_of_ice
+    - fraction_of_land
+    field io names:
+      totalSnowDepth: snwdph
+      filtered_orography: orog_filt
+      #fraction_of_ice: fice
+      fraction_of_land: land_frac
+    filename_sfcd: 20191201.000000.sfc_data.nc
+    filename_cplr: 20191201.000000.coupler.res
+    filename_orog: C96.mx100_oro_data.nc
+  background error:
+    covariance model: SABER
+    saber central block:
+      saber block name: BUMP_NICAS
+      read:
+        general:
+          universe length-scale: 300000.0
+        drivers:
+          multivariate strategy: univariate
+          read global nicas: true
+        nicas:
+          explicit length-scales: true
+          horizontal length-scale:
+          - groups:
+            - totalSnowDepth_shadowLevels
+            value: 250000.0
+          vertical length-scale:
+          - groups:
+            - totalSnowDepth_shadowLevels
+            value: 0.0
+          interpolation type:
+          - groups:
+            - totalSnowDepth_shadowLevels
+            type: c0
+          same horizontal convolution: true
+        io:
+          data directory: /scratch4/NCEPDEV/land/data/DA/bump_snow/
+          files prefix: snow_bump_nicas_250km_shadowlevels
+    saber outer blocks:
+    - saber block name: ShadowLevels
+      fields metadata:
+        totalSnowDepth:
+          vert_coord: filtered_orography
+      calibration:
+        number of shadow levels: 50
+        lowest shadow level: -450.0
+        highest shadow level: 8850.0
+        vertical length-scale: 2000.0
+    - saber block name: BUMP_StdDev
+      read:
+        drivers:
+          compute variance: true
+        variance:
+          explicit stddev: true
+          stddev:
+          - variables:
+            - totalSnowDepth
+            value: 30.0
+  observations:
+    obs perturbations: false
+    observers:
+    - obs space:
+        name: ghcn_snow
+        obsdatain:
+          engine:
+            type: H5File
+            obsfile: GHCN_2019120100.nc
+            missing file action: warn
+        obsdataout:
+          engine:
+            type: H5File
+            obsfile: output/DA/hofx/var_hofx_ghcn_2019120100.nc
+        simulated variables:
+        - totalSnowDepth
+      obs operator:
+        name: Identity
+      obs pre filters:
+      - filter: Create Diagnostic Flags
+        flags:
+        - name: missing_snowdepth
+          initial value: false
+        - name: missing_elevation
+          initial value: false
+        - name: invalid_snowdepth
+          initial value: false
+        - name: invalid_elevation
+          initial value: false
+        - name: land_check
+          initial value: false
+        - name: landice_check
+          initial value: false
+        - name: seaice_check
+          initial value: false
+        - name: elevation_bkgdiff
+          initial value: false
+        - name: rejectlist
+          initial value: false
+        - name: background_check
+          initial value: false
+      - filter: Perform Action
+        filter variables:
+        - name: totalSnowDepth
+        action:
+          name: assign error
+          error parameter: 40.0
+      - filter: Domain Check
+        where:
+        - variable:
+            name: ObsValue/totalSnowDepth
+          value: is_valid
+        actions:
+        - name: set
+          flag: missing_snowdepth
+          ignore: rejected observations
+        - name: reject
+      - filter: Domain Check
+        where:
+        - variable:
+            name: MetaData/stationElevation
+          value: is_valid
+        actions:
+        - name: set
+          flag: missing_elevation
+          ignore: rejected observations
+        - name: reject
+      obs prior filters:
+      - filter: Bounds Check
+        filter variables:
+        - name: totalSnowDepth
+        minvalue: 0.0
+        maxvalue: 20000.0
+        actions:
+        - name: set
+          flag: invalid_snowdepth
+          ignore: rejected observations
+        - name: reject
+      - filter: Domain Check
+        where:
+        - variable:
+            name: GeoVaLs/fraction_of_land
+          minvalue: 0.5
+        actions:
+        - name: set
+          flag: land_check
+          ignore: rejected observations
+        - name: reject
+      - filter: Domain Check
+        where:
+        - variable:
+            name: MetaData/stationElevation
+          minvalue: -200.0
+          maxvalue: 9900.0
+        actions:
+        - name: set
+          flag: invalid_elevation
+          ignore: rejected observations
+        - name: reject
+      #- filter: Domain Check
+      #  where:
+      #  - variable:
+      #      name: GeoVaLs/fraction_of_ice
+      #    maxvalue: 0.0
+      #  actions:
+      #  - name: set
+      #    flag: seaice_check
+      #    ignore: rejected observations
+      #  - name: reject
+      - filter: RejectList
+        where:
+        - variable:
+            name: GeoVaLs/vtype
+          minvalue: 14.5
+          maxvalue: 15.5
+        actions:
+        - name: set
+          flag: landice_check
+          ignore: rejected observations
+        - name: reject
+      - filter: Difference Check
+        reference: MetaData/stationElevation
+        value: GeoVaLs/filtered_orography
+        threshold: 800.0
+        actions:
+        - name: set
+          flag: elevation_bkgdiff
+          ignore: rejected observations
+        - name: reject
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/elevation_diff
+          type: float
+          function:
+            name: ObsFunction/Arithmetic
+            options:
+              variables:
+              - MetaData/stationElevation
+              - GeoVaLs/filtered_orography
+              coefficients:
+              - 1.0
+              - -1.0
+              total exponent: 2
+              total coefficient: 1.5625e-06
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/elevation_diff_exp
+          type: float
+          function:
+            name: ObsFunction/Exponential
+            options:
+              variables:
+              - DerivedMetaData/elevation_diff
+              coeffA: 1.0
+              coeffB: -1.0
+              coeffC: 0.0
+              coeffD: 1.0
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/elevation_diff_exp_inv
+          type: float
+          function:
+            name: ObsFunction/Arithmetic
+            options:
+              variables:
+              - DerivedMetaData/elevation_diff_exp
+              total exponent: -1.0
+      - filter: Perform Action
+        filter variables:
+        - name: totalSnowDepth
+        where:
+        - variable:
+            name: ObsValue/totalSnowDepth
+          minvalue: 0.0
+        action:
+          name: inflate error
+          inflation variable: DerivedMetaData/elevation_diff_exp_inv
+      - filter: BlackList
+        where:
+        - variable:
+            name: MetaData/stationIdentification
+          is_in:
+          - fakelist
+        actions:
+        - name: set
+          flag: rejectlist
+          ignore: rejected observations
+        - name: reject
+      obs post filters:
+      - filter: Background Check
+        filter variables:
+        - name: totalSnowDepth
+        absolute threshold: 250
+        bias correction parameter: 1.0
+        actions:
+        - name: set
+          flag: background_check
+          ignore: rejected observations
+        - name: reject
+variational:
+  minimizer:
+    algorithm: DRPCG
+  iterations:
+  - ninner: 50
+    gradient norm reduction: 1e-10
+    test: true
+    geometry:
+      fms initialization:
+        namelist filename: Data/fv3files/fmsmpp.nml
+        field table filename: Data/fv3files/field_table_gfdl
+      akbk: Data/fv3files/akbk127.nc4
+      #layout:
+      #- 5
+      #- 5
+      npx: 97
+      npy: 97
+      npz: 127
+      time invariant fields:
+        state fields:
+          datetime: '2019-12-01T00:00:00Z'
+          filetype: fms restart
+          skip coupler file: true
+          state variables:
+          - filtered_orography
+          - fraction_of_land
+          field io names:
+            filtered_orography: orog_filt
+            fraction_of_land: land_frac
+          #datapath: 
+          filename_orog: C96.mx100_oro_data.nc
+    diagnostics:
+      departures: bkgmob
+final:
+  diagnostics:
+    departures: anlmob
+  prints:
+    frequency: PT3H
+  increment:
+    output:
+      state component:
+        datapath: ./
+        prefix: snowinc
+        filetype: fms restart
+        filename_sfcd: 20191201.000000.sfc_data.nc
+        filename_cplr: 20191201.000000.coupler.res
+        state variables:
+        - totalSnowDepth
+        - vtype
+        - slmsk
+        field io names:
+          totalSnowDepth: snwdph
+    geometry:
+      fms initialization:
+        namelist filename: Data/fv3files/fmsmpp.nml
+        field table filename: Data/fv3files/field_table_gfdl
+      akbk: Data/fv3files/akbk127.nc4
+      #layout:
+      #- 5
+      #- 5
+      npx: 97
+      npy: 97
+      npz: 127
+final j evaluation: false

--- a/jedi/ioda/ghcn_snod2ioda.py
+++ b/jedi/ioda/ghcn_snod2ioda.py
@@ -1,0 +1,1 @@
+/scratch4/BMC/gsienkf/Clara.Draper/gerrit-hera/global-workflow/sorc/gdas.cd//sorc/iodaconv/src/land/ghcn_snod2ioda.py

--- a/jedi/ioda/ghcn_snod2ioda.py
+++ b/jedi/ioda/ghcn_snod2ioda.py
@@ -1,1 +1,0 @@
-/scratch4/BMC/gsienkf/Clara.Draper/gerrit-hera/global-workflow/sorc/gdas.cd//sorc/iodaconv/src/land/ghcn_snod2ioda.py

--- a/make_links.sh
+++ b/make_links.sh
@@ -14,11 +14,21 @@ if [[ -e $gdasdir ]]; then
 fi
 ln -fs $GDASApp_path $gdasdir
 
+# link fix files
+fixdir="./fix"
+if [[ -e $fixdir ]]; then
+  rmdir $fixdir
+fi
+
 # link fv3files
+
 fv3files="jedi/fv3-jedi/Data/fv3files"
 if [[ -e $fv3files ]]; then
   rm $fv3files
 fi
 ln -fs ${GDASApp_path}/build/fv3-jedi/test/Data/fv3files $fv3files
 
+# link ioda converters 
 
+# ghcn
+ln -fs ${GDASApp_path}/sorc/iodaconv/src/land/ghcn_snod2ioda.py jedi/ioda/ghcn_snod2ioda.py 

--- a/make_links.sh
+++ b/make_links.sh
@@ -16,10 +16,7 @@ fi
 ln -fs $GDASApp_path $gdasdir
 
 # link fix files
-fixdir="./fix"
-if [[ -e $fixdir ]]; then
-  rmdir $fixdir
-fi
+
 
 # link fv3files
 
@@ -31,5 +28,5 @@ ln -fs ${GDASApp_path}/build/fv3-jedi/test/Data/fv3files $fv3files
 
 # link ioda converters 
 
-# ghcn
+# ghcn - temporary until IODA converter PR merged. July 30, 2025.
 ln -fs ${GDASApp_path}/sorc/iodaconv/src/land/ghcn_snod2ioda.py jedi/ioda/ghcn_snod2ioda.py 

--- a/make_links.sh
+++ b/make_links.sh
@@ -4,7 +4,8 @@ if [ $# == 1 ]; then
         echo "setting jedi path to input $1"
         GDASApp_path=$1
 else 
-        GDASApp_path="/scratch2/NCEPDEV/land/data/DA/GDASApp_20250207/"
+        # temporary: July 30, 2025. Waiting for new GHCN IODA converter to be merged.
+        GDASApp_path="/scratch4/BMC/gsienkf/Clara.Draper/gerrit-hera/global-workflow/sorc/gdas.cd/" 
 fi 
 
 # create link to GDASApp with executables:


### PR DESCRIPTION

## Describe your changes  

Updates DA code to use latest version of JEDI from GDASApp (currently hard-coded to Clara's compiled version) 
-above includes updating the GHCN IODA converter to run on the fly, instead of pre-processing the GHCN obs 
-update scratch2 to scratch4 for hera to ursa migration 

Note: currently the GHCN 2DVar yaml is specified, rather than constructed. This is an intermediate PR and the next step will be to replace the yaml creation with JCB.

Note 2: Running these changes requires updating the land-offline_workflow to start the cycle at 12, rather than 0 - the offline_workflow should not yet be updated to use this hash.

## Issue ticket number and link
List the git Issue that this PR addresses issue [36](https://github.com/NOAA-PSL/land-DA_update/issues/36)


## Test output 

The test is expected to fail the comparison test, since the GHCN observations have changed. The differences are consistent with expectations.


## Checklist before requesting a review
- [x ] My branch being merged is up to date with the latest develop. 
- [x ] I have performed a self-review of my code by examining the differences that will be merged.
- [ x] I have not made any unnecessary code changes / changed any default behavior.
- [ x] My code passes the DA_IMS_test, or differences can be explained. 

