### PR TITLE
Update .gitmodules to point to EMC repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,9 @@
 [submodule "IMS_proc"]
 	path = IMS_proc
-	url = https://github.com/NOAA-PSL/land-SCF_proc.git
+	url = https://github.com/NOAA-EMC/land-SCF_proc.git
 	branch = develop
 
 [submodule "add_jedi_incr"]
 	path = add_jedi_incr
-	url = https://github.com/NOAA-PSL/land-apply_jedi_incr.git
+	url = https://github.com/NOAA-EMC/land-apply_jedi_incr.git
+    branch = develop


### PR DESCRIPTION
A small change to point the add-jedi-incr and IMS processing submodules to the EMC repo that are up to date and have been tested in global workflow GFSv17 

